### PR TITLE
fix(baseof.html): resolve deprecated resources.PostCSS

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -57,7 +57,7 @@
     
     <!-- Main CSS -->
     {{ $css := resources.Get "css/main.css" }}
-    {{ $css = $css | resources.PostCSS }}
+    {{ $css = $css | css.PostCSS }}
     {{ if hugo.IsProduction }}
         {{ $css = $css | minify | fingerprint | resources.PostProcess }}
     {{ end }}


### PR DESCRIPTION
ERROR deprecated: resources.PostCSS was deprecated in Hugo v0.128.0 and will be removed in Hugo 0.141.0. Use css.PostCSS instead.