### PR TITLE
Improve install doc

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -132,7 +132,16 @@ cp themes/hugo-saasify-theme/tailwind.config.copy.js ./tailwind.config.js
 npm install
 ```
 
-#### Step 6: Start Development Server
+#### Step 6: Set the theme in hugo.toml
+
+Open your `hugo.toml` and check that the theme is correctly set:
+
+```toml
+# Theme Configuration
+theme = "hugo-saasify-theme"
+```
+
+#### Step 7: Start Development Server
 
 ```bash
 # Start development server (builds TailwindCSS and runs Hugo server)


### PR DESCRIPTION
## Problem

When I followed the installation guide step by step, the last step `npm run start` would fail because the theme was not set in hugo.toml.

By default after initializing a fresh project the theme is "../..", which won't work.

It's probably obvious for people familiar with Hugo but I thought it would be nice to add it for clarity. 