### PR TITLE
Fix small bug with favicon param in baseof.html

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -48,7 +48,7 @@
     {{ end }}
 
     <!-- Favicon -->
-    <link rel="icon" type="image/x-icon" href="{{ "images/favicon.ico" | relURL }}">
+    <link rel="icon" type="image/x-icon" href="{{ .Site.Params.favicon | relURL }}">
     
     <!-- Canonical URL -->
     <link rel="canonical" href="{{ .Permalink }}">


### PR DESCRIPTION
The baseof.html default layout was hardcoding the path to a favicon, ignoring the value set in the configuration file. This small patch uses the param instead of hardcoding.