### PR TITLE
Fix live reload by linking directly to built style.css

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -58,13 +58,8 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Plus+Jakarta+Sans:wght@600;700;800&display=swap" rel="stylesheet">
     
-    <!-- Main CSS -->
-    {{ $css := resources.Get "css/main.css" }}
-    {{ $css = $css | css.PostCSS }}
-    {{ if hugo.IsProduction }}
-        {{ $css = $css | minify | fingerprint | resources.PostProcess }}
-    {{ end }}
-    <link rel="stylesheet" href="{{ $css.RelPermalink }}">
+    <!-- Main CSS (built by the `tailwindcss` CLI watch/build script, see package.json) -->
+    <link rel="stylesheet" href="/css/style.css">
 
     <!-- Additional Meta Tags from Front Matter -->
     {{ with .Params.customMeta }}


### PR DESCRIPTION
## Summary
- `baseof.html` ran its own Hugo Pipes/PostCSS pass on `css/main.css`, completely separate from the `tailwindcss` CLI watch process that `package.json`'s npm scripts already run into `static/css/style.css`
- Hugo's asset pipeline doesn't reliably know to reprocess `main.css` when a template's Tailwind classes change, so the page kept serving stale CSS during local dev
- Link directly to the file the documented dev/build workflow already produces instead of running a second, redundant compile

## Test plan
- [x] `npm start` in `exampleSite/` — dev server starts cleanly with no PostCSS/Node permission errors
- [x] Added a novel Tailwind class (`rotate-[17deg]`) to a template while the server was running, confirmed the watcher recompiled `style.css`, and confirmed in a real browser (computed styles + screenshot) that it applied immediately with no restart
- [x] `npm run build` (production) — output HTML links `/css/style.css`, file is minified as expected
- [x] Manual pass over home/pricing/blog/docs pages to confirm no styling regressions from removing the old pipeline

Fixes #37