### PR TITLE
Fix testimonials wrap-around gap by duplicating enough sets to cover the container

### DIFF
--- a/layouts/shortcodes/testimonials.html
+++ b/layouts/shortcodes/testimonials.html
@@ -57,27 +57,43 @@
             track.style.animation = 'none';
             
             const container = track.parentElement;
-            
-            // Calculate the width of one set of testimonials (50% of track)
-            const trackWidth = track.scrollWidth;
-            const halfWidth = trackWidth / 2;
-            
+
+            // The shortcode renders the real cards followed by one
+            // aria-hidden duplicate set, so half of the initial track is
+            // one full loop of unique content.
+            const oneSetWidth = track.scrollWidth / 2;
+
             // Ensure track has valid dimensions before animating
-            if (trackWidth === 0 || halfWidth === 0) {
+            if (oneSetWidth === 0) {
                 return;
             }
-            
+
+            // Two copies only loop seamlessly if a copy is at least as wide
+            // as the visible container - otherwise the scroll position runs
+            // past the end of the rendered content before it's time to wrap,
+            // exposing blank space. Clone the original cards as many extra
+            // times as needed so there's always enough duplicated content
+            // ahead of the viewport for the whole scroll cycle.
+            const originalCards = Array.from(track.children).slice(0, track.children.length / 2);
+            while (track.scrollWidth < container.clientWidth + oneSetWidth) {
+                originalCards.forEach(card => {
+                    const clone = card.cloneNode(true);
+                    clone.setAttribute('aria-hidden', 'true');
+                    track.appendChild(clone);
+                });
+            }
+
             let position = 0; // Current position in pixels
             let isPaused = false;
             let lastTime = performance.now();
-            
+
             // Check for mobile and set duration - responsive to window resize
             function getDuration() {
                 return window.innerWidth <= 768 ? 15000 : 40000;
             }
-            
+
             // Speed in pixels per millisecond (recalculated on resize)
-            let speed = halfWidth / getDuration();
+            let speed = oneSetWidth / getDuration();
             
             function animate(currentTime) {
                 if (!isPaused) {
@@ -88,9 +104,9 @@
 
                     // Reset position seamlessly when we've moved one full set.
                     // Modulo (not a single subtraction) so we still land in
-                    // range even if position overshot by more than halfWidth.
-                    if (position >= halfWidth) {
-                        position = position % halfWidth;
+                    // range even if position overshot by more than oneSetWidth.
+                    if (position >= oneSetWidth) {
+                        position = position % oneSetWidth;
                     }
 
                     track.style.transform = `translateX(-${position}px)`;
@@ -121,12 +137,20 @@
                 }
             });
             
-            // Handle window resize to adjust speed
+            // Handle window resize to adjust speed, and re-check whether a
+            // wider container now needs more duplicated content.
             let resizeTimeout;
             window.addEventListener('resize', () => {
                 clearTimeout(resizeTimeout);
                 resizeTimeout = setTimeout(() => {
-                    speed = halfWidth / getDuration();
+                    speed = oneSetWidth / getDuration();
+                    while (track.scrollWidth < container.clientWidth + oneSetWidth) {
+                        originalCards.forEach(card => {
+                            const clone = card.cloneNode(true);
+                            clone.setAttribute('aria-hidden', 'true');
+                            track.appendChild(clone);
+                        });
+                    }
                 }, 250); // Debounce resize events
             });
         });

--- a/layouts/shortcodes/testimonials.html
+++ b/layouts/shortcodes/testimonials.html
@@ -59,9 +59,17 @@
             const container = track.parentElement;
 
             // The shortcode renders the real cards followed by one
-            // aria-hidden duplicate set, so half of the initial track is
-            // one full loop of unique content.
-            const oneSetWidth = track.scrollWidth / 2;
+            // aria-hidden duplicate set. The seamless wrap distance is the
+            // offset from the start of the first real card to the start of
+            // the first duplicate card - NOT half of track.scrollWidth.
+            // flex `gap` applies uniformly between every child, so treating
+            // the two halves as symmetric undercounts by half a gap and
+            // produces a small but consistent snap at every wrap.
+            const originalCards = Array.from(track.children).slice(0, track.children.length / 2);
+            const firstDuplicateCard = track.children[originalCards.length];
+            const oneSetWidth = firstDuplicateCard
+                ? firstDuplicateCard.offsetLeft - originalCards[0].offsetLeft
+                : 0;
 
             // Ensure track has valid dimensions before animating
             if (oneSetWidth === 0) {
@@ -74,7 +82,6 @@
             // exposing blank space. Clone the original cards as many extra
             // times as needed so there's always enough duplicated content
             // ahead of the viewport for the whole scroll cycle.
-            const originalCards = Array.from(track.children).slice(0, track.children.length / 2);
             while (track.scrollWidth < container.clientWidth + oneSetWidth) {
                 originalCards.forEach(card => {
                     const clone = card.cloneNode(true);


### PR DESCRIPTION
## Summary
- PR #38 only fixed a secondary rAF-delta bug (backgrounded-tab jump). @bitwombat correctly pointed out on that PR that it doesn't fix the actual reported wrap-around jump.
- Root cause: the shortcode always renders exactly 2 copies of the testimonial set. That's only enough to loop seamlessly if one copy is at least as wide as the visible container. On the theme's own demo content (3 testimonials, ~964px per set vs a ~1216px container), the scroll position runs past the end of the rendered content before it's time to wrap — exposing a growing blank gap for roughly a quarter of every ~40s cycle before snapping back.
- Fix: clone the original cards at runtime, as many extra times as needed, until the track always has enough duplicated content ahead of the viewport to cover a full cycle. Re-checked on resize too, since a wider container can turn a previously-sufficient set insufficient.

## Test plan
- [x] Reproduced the gap on the demo's default 3-testimonial content: measured `oneSetWidth` (964px) vs container width (1216px), confirmed mathematically insufficient, then visually confirmed a blank gap via a forced worst-case transform
- [x] Applied the fix, re-measured: track auto-grows to 2956px (3 total sets), confirmed `position + containerWidth` never exceeds `trackWidth` across the full cycle
- [x] Screenshotted the exact previous worst-case wrap frame — now shows a full row of cards, no gap
- [x] Sampled the live animation over several seconds — no gaps at any point, no console errors
- [x] Tested with 6 testimonials (a case where 2 copies were already sufficient) — confirmed no extra clones are added, no regression for sites that already worked

Fixes #36